### PR TITLE
Fix: Friend Server Notifications not being evaluated correctly

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -233,7 +233,6 @@ export default definePlugin({
             if (
                 (
                     (message.author.id === currentUser.id) // If message is from the user.
-                    || (!MuteStore.allowAllMessages(channel)) // If user has muted the channel.
                     || (channel.id === SelectedChannelStore.getChannelId()) // If the user is currently in the channel.
                     || (ignoredUsers.includes(message.author.id)) // If the user is ignored.
                 )
@@ -244,7 +243,7 @@ export default definePlugin({
                 return;
             }
 
-            if (!settings.store.directMessages && channel.isDM() || !settings.store.groupMessages && channel.isGroupDM()) return;
+            if (!settings.store.directMessages && channel.isDM() || !settings.store.groupMessages && channel.isGroupDM() || MuteStore.isChannelMuted(null, channel.id)) return;
 
             // Prepare the notification.
             const Notification: NotificationData = {
@@ -400,7 +399,7 @@ function findNotificationLevel(channel: Channel): NotificationLevel {
     const store = Vencord.Webpack.findStore("UserGuildSettingsStore");
     const userGuildSettings = store.getAllSettings().userGuildSettings[channel.guild_id];
 
-    if (!settings.store.determineServerNotifications) {
+    if (!settings.store.determineServerNotifications || MuteStore.isGuildOrCategoryOrChannelMuted(channel.guild_id, channel.id)) {
         return NotificationLevel.NO_MESSAGES;
     }
 
@@ -427,7 +426,7 @@ async function handleGuildMessage(message: Message) {
     const c = ChannelStore.getChannel(message.channel_id);
     const notificationLevel: number = findNotificationLevel(c);
 
-    console.log("[NOTIFICATION LEVEL] " + notificationLevel);
+    // console.log("[NOTIFICATION LEVEL] " + notificationLevel); // Avoid nuking the whole console
 
     // todo: check if the user who sent it is a friend
     const all = notifyFor.includes(message.channel_id);


### PR DESCRIPTION
Friend Server Notifications were previously ignored if the notification setting wasn't set to "All messages" (due to a check added with "Determine Server Notifications"). You can read about the new behaviour below:

- If "Friend Server Notifications" are enabled, all messages sent by friends in servers will cause a notification to be sent - ignoring both the Notification setting and whether the channel/category/server is muted.
- If the messages are not from a friend and "Determine Server Notifications" is on, the mute of the channel/category/server will be taken into account when evaluating whether to send a notification.
- If a DM or group message is received and the user has muted the conversation, no notification will be sent (regardless whether it's from a friend or not as "Friend **Server** Notifications" doesn't affect this). 